### PR TITLE
update pmd version to latest available

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ try {
 }
 
 function installPMD(){
-  var download = 'wget https://github.com/pmd/pmd/releases/download/pmd_releases%2F6.19.0/pmd-bin-6.19.0.zip -P /tmp'
+  var download = 'wget https://github.com/pmd/pmd/releases/download/pmd_releases%2F7.6.0/pmd-dist-7.6.0-bin.zip -P /tmp'
   var unzip = 'unzip /tmp/pmd-bin-6.19.0.zip -d /tmp'
   var mk = 'mkdir $HOME/pmd'
   var mv = 'mv /tmp/pmd-bin-6.19.0/* $HOME/pmd'


### PR DESCRIPTION
Current version of PMD that is being used in this action, is not updated to use the `Assert` class of apex and throws this error:
`Apex unit test classes should have at least one System.assert() or assertEquals() or AssertNotEquals() call`